### PR TITLE
Add error handling for API response

### DIFF
--- a/sbident/sbident.py
+++ b/sbident/sbident.py
@@ -241,6 +241,7 @@ class SBIdent:
 
 		# read & set json
 		response = requests.get(self.uri)
+		response.raise_for_status()
 		json = response.json()
 		self.json = json
 


### PR DESCRIPTION
This is a small change to handle errors, such as time-outs, when calling the SBIdent API.

Currently, if the API call fails, a `JSONDecodeError` is raised, which hide the true cause of the error:
```
>>> time = Time(58752.98762200553, format='mjd')
>>> center = SkyCoord(222.25000416666663 * u.deg, -15.5 * u.deg)
>>> s1 = SBIdent('W84', time, center, hwidth=1.5, precision='high', request=True)
Traceback (most recent call last):
  File "/nvme/users/stevengs/opt_lsst/conda/envs/lsst-scipipe-8.0.0/lib/python3.11/site-packages/requests/models.py", line 971, in json
    return complexjson.loads(self.text, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/users/stevengs/opt_lsst/conda/envs/lsst-scipipe-8.0.0/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/users/stevengs/opt_lsst/conda/envs/lsst-scipipe-8.0.0/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nvme/users/stevengs/opt_lsst/conda/envs/lsst-scipipe-8.0.0/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nvme/users/stevengs/opt_lsst/conda/envs/lsst-scipipe-8.0.0/lib/python3.11/site-packages/sbident/sbident.py", line 202, in __init__
    self.make_request()
  File "/nvme/users/stevengs/opt_lsst/conda/envs/lsst-scipipe-8.0.0/lib/python3.11/site-packages/sbident/sbident.py", line 304, in make_request
    self.read_uri()
  File "/nvme/users/stevengs/opt_lsst/conda/envs/lsst-scipipe-8.0.0/lib/python3.11/site-packages/sbident/sbident.py", line 244, in read_uri
    json = response.json()
           ^^^^^^^^^^^^^^^
  File "/nvme/users/stevengs/opt_lsst/conda/envs/lsst-scipipe-8.0.0/lib/python3.11/site-packages/requests/models.py", line 975, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This change will produce the actual error message (time-out) instead of the `JSONDecodeError`:
```
>>> s2 = SBIdent('W84', time, coord, hwidth=1.5, precision='high', request=False)
>>> r2 = requests.get(s2.uri)
>>> r2.raise_for_status()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/nvme/users/stevengs/opt_lsst/conda/envs/lsst-scipipe-8.0.0/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 504 Server Error: Gateway Time-out for url: https://ssd-api.jpl.nasa.gov/sb_ident.api?mpc-code=W84&obs-time=2019-09-26+23%3A42%3A11&fov-ra-center=14-49-00.00&fov-dec-center=M15-30-00.00&fov-ra-hwidth=1.5&fov-dec-hwidth=1.5&two-pass=true&suppress-first-pass=true&mag-required=true&req-elem=false
```